### PR TITLE
Add peer connection route to private subnet B

### DIFF
--- a/templates/vpc-management.template
+++ b/templates/vpc-management.template
@@ -87,6 +87,10 @@ Parameters:
         Description: Route Table ID for Prod VPC Private
         Type: String
         Default: ''
+    pRouteTableProdPrivateB:
+        Description: Route Table ID for Prod VPC Private
+        Type: String
+        Default: ''
     pRouteTableProdPublic:
         Description: Route Table ID for Prod VPC Public
         Type: String
@@ -472,6 +476,13 @@ Resources:
         Type: AWS::EC2::Route
         Properties:
             RouteTableId: !Ref pRouteTableProdPrivate
+            VpcPeeringConnectionId: !Ref rPeeringConnectionProduction
+            DestinationCidrBlock: !Ref pManagementCIDR
+    rRouteProdMgmtB:
+        Condition: cCreatePeeringProduction
+        Type: AWS::EC2::Route
+        Properties:
+            RouteTableId: !Ref pRouteTableProdPrivateB
             VpcPeeringConnectionId: !Ref rPeeringConnectionProduction
             DestinationCidrBlock: !Ref pManagementCIDR
     rRouteProdMgmtPublic:


### PR DESCRIPTION
The UK Official templates [quickstart-enterprise-accelerator-uk-official](https://github.com/aws-quickstart/quickstart-enterprise-accelerator-uk-official) are using the Bastion as a jump server into the instances on private subnet. The management VPC is create the peering but is only adding a route for Private subnet A.
This changes will allow access from the Bastion to resources in private subnet B. 