### PR TITLE
Expose network ACLs in outputs

### DIFF
--- a/templates/vpc-production.template
+++ b/templates/vpc-production.template
@@ -660,7 +660,11 @@ Outputs:
         Value: !Ref rDBPrivateSubnetA
     rDBPrivateSubnetB:
         Value: !Ref rDBPrivateSubnetB
-    rSecurityGroupSSHFromProd:
-        Value: !Ref rSecurityGroupSSHFromProd
+    rDBPrivateSubnetA:
+        Value: !Ref rDBPrivateSubnetA
+    rNACLPrivate:
+        Value: !Ref rNACLPrivate
+    rNACLPublic:
+        Value: !Ref rNACLPublic
     rSecurityGroupVpcNat:
         Value: !Ref rSecurityGroupVpcNat

--- a/templates/vpc-production.template
+++ b/templates/vpc-production.template
@@ -660,11 +660,11 @@ Outputs:
         Value: !Ref rDBPrivateSubnetA
     rDBPrivateSubnetB:
         Value: !Ref rDBPrivateSubnetB
-    rDBPrivateSubnetA:
-        Value: !Ref rDBPrivateSubnetA
     rNACLPrivate:
         Value: !Ref rNACLPrivate
     rNACLPublic:
         Value: !Ref rNACLPublic
+    rSecurityGroupSSHFromProd:
+        Value: !Ref rSecurityGroupSSHFromProd
     rSecurityGroupVpcNat:
         Value: !Ref rSecurityGroupVpcNat


### PR DESCRIPTION
The network ACLs must be exposed in order to add ACL entries from external stacks.  No conflicts occur from adding these outputs and it adds some useful functionality.  