### PR TITLE
Fix typo in rCloudTrailChange MetricFilter.

### DIFF
--- a/templates/logging.template
+++ b/templates/logging.template
@@ -380,7 +380,7 @@ Resources:
         Type: AWS::Logs::MetricFilter
         Properties:
             LogGroupName: !Ref rCloudTrailLogGroup
-            FilterPattern: '{($.eventSource = cloudtrail.amazonaws.com) && (($.eventName != Describe*) && ($.eventName != Get*) && ($.eventName != Lookup*) && ($.eventName != Lookup*))}'
+            FilterPattern: '{($.eventSource = cloudtrail.amazonaws.com) && (($.eventName != Describe*) && ($.eventName != Get*) && ($.eventName != Lookup*) && ($.eventName != List*))}'
             MetricTransformations:
               - MetricNamespace: CloudTrailMetrics
                 MetricName: CloudTrailChangeCount


### PR DESCRIPTION
Lookup* is listed twice. When I put this into production within my own AWS account, the filter did not capture List* events and thus the associated alarm triggered on non-consequential List* events. It is my belief that the inclusion of Lookup* twice is a typo.