### PR TITLE
Updated CloudTrail Filter

### DIFF
--- a/templates/logging.template
+++ b/templates/logging.template
@@ -471,7 +471,7 @@ Resources:
       LogGroupName: !Ref rCloudTrailLogGroup
       FilterPattern: '{($.eventSource = cloudtrail.amazonaws.com) && (($.eventName
         != Describe*) && ($.eventName != Get*) && ($.eventName != Lookup*) && ($.eventName
-        != Lookup*))}'
+        != List*))}'
       MetricTransformations:
       - MetricNamespace: CloudTrailMetrics
         MetricName: CloudTrailChangeCount


### PR DESCRIPTION
rCloudTrailChange, a CloudWatch logs filter for CloudTrail had "Lookup*" added twice and omited List*. This was causing false notifications that CloudTrail had been changed when it had not.