### PR TITLE
TreatMissingData for CW ALarms

### DIFF
--- a/templates/logging.template
+++ b/templates/logging.template
@@ -360,6 +360,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   rSecurityGroupChangesMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -392,6 +393,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   rIAMRootActivity:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -420,6 +422,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   rUnauthorizedAttempts:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -447,6 +450,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 5
+      TreatMissingData: notBreaching
   rIAMPolicyChangesAlarm:
     Type: AWS::CloudWatch::Alarm
     DependsOn: rUnauthorizedAttemptAlarm
@@ -461,6 +465,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   rIAMCreateAccessKeyAlarm:
     Type: AWS::CloudWatch::Alarm
     DependsOn: rIAMPolicyChangesAlarm
@@ -504,6 +509,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   rCloudTrailChange:
     Type: AWS::Logs::MetricFilter
     Properties:

--- a/templates/logging.template
+++ b/templates/logging.template
@@ -481,6 +481,7 @@ Resources:
       Period: 300
       Statistic: Sum
       Threshold: 1
+      TreatMissingData: notBreaching
   rIAMCreateAccessKey:
     Type: AWS::Logs::MetricFilter
     DependsOn: rIAMCreateAccessKeyAlarm


### PR DESCRIPTION
Had a customer get alarm emails due to insufficient data related to the cloudwatch alarms. Added the TreatMissingData to notBreaching as I think that is probably the most appropriate setting for these sporadically reported metrics.