### PR TITLE
Fixing CloudTrail Validation Function

### DIFF
--- a/templates/config-rules.template
+++ b/templates/config-rules.template
@@ -209,7 +209,7 @@ Resources:
 
           // Custom rule for evaluating CloudTrail configuration compliance
           // 3 config parameters for Trail must be true: Multi-Region, Global Services Events, and Log File Validation
-          function evaluateCompliance(configurationItem, ruleParameters, context) {
+          function evaluateCompliance(configurationItem, context) {
               if(configurationItem.resourceType !== 'AWS::CloudTrail::Trail')
                   return 'NOT_APPLICABLE';
 
@@ -227,11 +227,10 @@ Resources:
 
           exports.handler = function(event, context) {
               var invokingEvent = JSON.parse(event.invokingEvent);
-              var ruleParameters = JSON.parse(event.ruleParameters);
               var compliance = 'NOT_APPLICABLE';
 
               if (isApplicable(invokingEvent.configurationItem, event))
-                  compliance = evaluateCompliance(invokingEvent.configurationItem, ruleParameters, context); // Invoke the compliance checking function.
+                  compliance = evaluateCompliance(invokingEvent.configurationItem, context); // Invoke the compliance checking function.
 
               var putEvaluationsRequest = {
                   Evaluations: [
@@ -266,7 +265,7 @@ Resources:
       Description: Checks whether CloudTrail is enabled in this region.
       Scope:
         ComplianceResourceTypes:
-        - AWS::EC2::Instance
+        - AWS::CloudTrail::Trail
       Source:
         Owner: CUSTOM_LAMBDA
         SourceDetails:


### PR DESCRIPTION
CloudTrail Validation Function show no data when launched into AWS, with following error: 

"
SyntaxError: Unexpected token u
at Object.parse (native)
at exports.handler (/var/task/index.js:24:31)
"
Can be fixed by changing ComplianceResourceTypes (line 269, rConfigRuleForCloudTrail) to AWS::CloudTrail::Trail (instead of EC2 Instance), and by removing the parse  "var ruleParameters = JSON.parse(event.ruleParameters);" (line 230) and ruleParameters Objects (line 212 & line 234).