### PR TITLE
Fixes a race condition for EIP attachment

### DIFF
--- a/templates/vpc-management.template
+++ b/templates/vpc-management.template
@@ -408,6 +408,8 @@ Resources:
   AssociaterEIPProdBastion:
     Type: AWS::EC2::EIPAssociation
     Condition: cCreateBastionHost
+    DependsOn:
+      - rMgmtBastionInstance
     Properties:
       AllocationId: !GetAtt rEIPProdBastion.AllocationId
       NetworkInterfaceId: !Ref rENIProductionBastion


### PR DESCRIPTION
In some cases, CloudFormation may try to associate an elastic IP address
with the management bastion's NIC before it's done
launching/associating. This change adds a manual dependency on the
instance to prevent this race.