### PR TITLE
Update Lambda runtime twice in config-rules

### DIFF
--- a/templates/config-rules.template
+++ b/templates/config-rules.template
@@ -161,7 +161,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs6.10
       Timeout: 30
       Role:
         !GetAtt
@@ -253,7 +253,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs6.10
       Timeout: 30
       Role:
         !GetAtt

--- a/templates/config-rules.template
+++ b/templates/config-rules.template
@@ -161,7 +161,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: 30
       Role:
         !GetAtt
@@ -253,7 +253,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: 30
       Role:
         !GetAtt


### PR DESCRIPTION
Changed "Runtime: nodejs4.3" (unsupported; causes CloudFormation to fail) to "Runtime: nodejs6.10" (supported; CloudFormation succeeds) twice.