### PR TITLE
Bumping nodejs version to 8.10 fixing issue #20

### DIFF
--- a/templates/config-rules.template
+++ b/templates/config-rules.template
@@ -161,7 +161,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       Timeout: 30
       Role:
         !GetAtt
@@ -253,7 +253,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       Timeout: 30
       Role:
         !GetAtt


### PR DESCRIPTION
Hi team,

I have bumped the version of Node.js from 4.3 to 8.10 as it's no longer supported by AWS Lambda.

I have tested and it works properply.

Thanks.