### PR TITLE
us-gov-east-1 Support

### DIFF
--- a/templates/logging.template
+++ b/templates/logging.template
@@ -23,10 +23,7 @@ Parameters:
     Type: String
     Default: true
 Conditions:
-  IsGovCloud:
-    !Equals
-    - us-gov-west-1
-    - !Ref AWS::Region
+  IsGovCloud: !Or [!Equals [!Ref "AWS::Region", us-gov-west-1], !Equals [!Ref "AWS::Region", us-gov-east-1]]
   SupportsGlacier:
     !Equals
     - true

--- a/templates/vpc-management.template
+++ b/templates/vpc-management.template
@@ -202,10 +202,7 @@ Parameters:
       orward slash (/).
     Type: String
 Conditions:
-  cGovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+  cGovCloudCondition: !Or [!Equals [!Ref "AWS::Region", us-gov-west-1], !Equals [!Ref "AWS::Region", us-gov-east-1]]
   cCreateBastionHost:
     !Equals
     - true

--- a/templates/vpc-production.template
+++ b/templates/vpc-production.template
@@ -165,10 +165,7 @@ Parameters:
       forward slash (/).
     Type: String
 Conditions:
-  cGovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+  cGovCloudCondition: !Or [!Equals [!Ref "AWS::Region", us-gov-west-1], !Equals [!Ref "AWS::Region", us-gov-east-1]]
   cNeedNatInstance:
     !Equals
     - false


### PR DESCRIPTION
*Issue #, if available:* `us-gov-east-1` was not supported.

*Description of changes:*
- Modified the `IsGovCloud` to check `!Or [!Equals [!Ref "AWS::Region", us-gov-west-1], !Equals [!Ref "AWS::Region", us-gov-east-1]]` so that it will properly use the `aws-us-gov` partition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.