### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/templates/config-rules.template
+++ b/templates/config-rules.template
@@ -161,7 +161,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role:
         !GetAtt
@@ -253,7 +253,7 @@ Resources:
               });
           };
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: 30
       Role:
         !GetAtt


### PR DESCRIPTION
CloudFormation templates in quickstart-compliance-common have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.