### PR TITLE
Fixing syntax error in Python Lambda function

### DIFF
--- a/templates/config-rules.template
+++ b/templates/config-rules.template
@@ -150,7 +150,7 @@ Resources:
                     return 'COMPLIANT'
                 return "NON_COMPLIANT"
 
-            def evaulate_ami_compliance(config_item, rule_params, context);
+            def evaulate_ami_compliance(config_item, rule_params, context):
               ami_id_list = rule_parms['amiList'].split(',')
               if config_item['configuration']['imageId'] in ami_id_list:
                 return 'COMPLIANT'


### PR DESCRIPTION
*Description of changes:*
Just changing a semicolon character ';' to the correct colon character ':'.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
