### PR TITLE
Adding NAT instance conditions and route from mgmt to prod subnet B

### DIFF
--- a/templates/vpc-management.template
+++ b/templates/vpc-management.template
@@ -98,6 +98,10 @@ Parameters:
     Description: Route Table ID for Prod VPC Private
     Type: String
     Default: ''
+  pRouteTableProdPrivateB:
+    Description: Route Table ID for Prod VPC PrivateB (optional)
+    Type: String
+    Default: ''
   pRouteTableProdPublic:
     Description: Route Table ID for Prod VPC Public
     Type: String
@@ -219,6 +223,11 @@ Conditions:
     - !Equals
       - ''
       - !Ref pProductionVPC
+  cSecondProdRouteTable:
+    !Not
+    - !Equals
+      - ''
+      - !Ref pRouteTableProdPrivateB
   cNeedNatInstance:
     !Equals
     - false
@@ -271,6 +280,7 @@ Resources:
         pEipNatAllocationId: !GetAtt rEIPProdNAT.AllocationId
   rSecurityGroupVpcNat:
     Type: AWS::EC2::SecurityGroup
+    Condition: cNeedNatInstance
     Properties:
       GroupDescription: Allow NAT from Management VPC
       VpcId: !Ref rVPCManagement
@@ -420,6 +430,7 @@ Resources:
       Domain: vpc
   rSecurityGroupSSHFromMgmt:
     Type: AWS::EC2::SecurityGroup
+    Condition: cNeedNatInstance
     Properties:
       GroupDescription: Enable SSH access via port 22
       VpcId: !Ref rVPCManagement
@@ -435,6 +446,7 @@ Resources:
         Value: !Ref pEnvironment
   rManagementNATInstanceInterface:
     Type: AWS::EC2::NetworkInterface
+    Condition: cNeedNatInstance
     Properties:
       SubnetId: !Ref rManagementDMZSubnetA
       GroupSet:
@@ -518,6 +530,13 @@ Resources:
       RouteTableId: !Ref pRouteTableProdPrivate
       VpcPeeringConnectionId: !Ref rPeeringConnectionProduction
       DestinationCidrBlock: !Ref pManagementCIDR
+  rRouteProdMgmtB:
+    Condition: cSecondProdRouteTable
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref pRouteTableProdPrivate
+      VpcPeeringConnectionId: !Ref rPeeringConnectionProduction
+      DestinationCidrBlock: !Ref pManagementCIDR
   rRouteProdMgmtPublic:
     Condition: cCreatePeeringProduction
     Type: AWS::EC2::Route
@@ -595,9 +614,12 @@ Outputs:
   rRouteTableMgmtDMZ:
     Value: !Ref rRouteTableMgmtDMZ
   rSecurityGroupVpcNat:
+    Condition: cNeedNatInstance
     Value: !Ref rSecurityGroupVpcNat
   rEIPManagementNAT:
+    Condition: cNeedNatInstance
     Value: !Ref rEIPProdNAT
   rSecurityGroupSSHFromMgmt:
+    Condition: cNeedNatInstance
     Value: !Ref rSecurityGroupSSHFromMgmt
 ...

--- a/templates/vpc-production.template
+++ b/templates/vpc-production.template
@@ -24,6 +24,7 @@ Metadata:
         default: Production VPC Config
       Parameters:
       - pBastionSSHCIDR
+      - pMgmtSSHCIDR
       - pProductionVPCName
       - pProductionCIDR
       - pDMZSubnetACIDR
@@ -59,6 +60,8 @@ Metadata:
         default: CIDR block of Database B subnet (private)
       pEC2KeyPair:
         default: Name of existing SSH Key for NAT Instance
+      pMgmtSSHCIDR:
+        default: CIDR block of Management VPC for SSH access
       pVPCTenancy:
         default: Instance tenancy
       QSS3BucketName:
@@ -70,6 +73,10 @@ Metadata:
 Parameters:
   pBastionSSHCIDR:
     Description: CIDR block to allow access to bastion SSH
+    Type: String
+    Default: 0.0.0.0/0
+  pMgmtSSHCIDR:
+    Description: CIDR block to allow access from management VPC
     Type: String
     Default: 0.0.0.0/0
   pRegionAZ1Name:
@@ -201,6 +208,7 @@ Resources:
         Value: !Ref pEnvironment
   rSecurityGroupVpcNat:
     Type: AWS::EC2::SecurityGroup
+    Condition: cNeedNatInstance
     Properties:
       GroupDescription: Allow NAT from production
       VpcId: !Ref rVPCProduction
@@ -235,6 +243,7 @@ Resources:
         Value: !Ref pEnvironment
   rSecurityGroupSSHFromProd:
     Type: AWS::EC2::SecurityGroup
+    Condition: cNeedNatInstance
     Properties:
       GroupDescription: Enable SSH access via port 22
       VpcId: !Ref rVPCProduction
@@ -551,7 +560,7 @@ Resources:
   rNACLRuleAllowBastionSSHAccessPublic:
     Type: AWS::EC2::NetworkAclEntry
     Properties:
-      CidrBlock: 0.0.0.0/0
+      CidrBlock: !Ref pMgmtSSHCIDR
       Protocol: 6
       PortRange:
         From: 22
@@ -684,7 +693,9 @@ Outputs:
   rNACLPublic:
     Value: !Ref rNACLPublic
   rSecurityGroupSSHFromProd:
+    Condition: cNeedNatInstance
     Value: !Ref rSecurityGroupSSHFromProd
   rSecurityGroupVpcNat:
+    Condition: cNeedNatInstance
     Value: !Ref rSecurityGroupVpcNat
 ...


### PR DESCRIPTION
*Description of changes:*

1) Added parameter pMgmtSSHCIDR with 0.0.0.0/0 as the default value, replaced the hard-coded value
2) Added optional parameter "pRouteTableProdPrivateB" to vpc-management.template that, if it has a value, creates a new route
3) Made the NAT security groups conditional


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
