### PR TITLE
Fix IPs for Private subnets

### DIFF
--- a/templates/vpc-production.template
+++ b/templates/vpc-production.template
@@ -111,15 +111,15 @@ Parameters:
   pAppPrivateSubnetBCIDR:
     Description: CIDR block for Application AZ-1b subnet
     Type: String
-    Default: 10.100.119.0/21
+    Default: 10.100.112.0/21
   pDBPrivateSubnetACIDR:
     Description: CIDR block for Private AZ-1a subnet
     Type: String
-    Default: 10.100.194.0/21
+    Default: 10.100.192.0/21
   pDBPrivateSubnetBCIDR:
     Description: CIDR block for Private AZ-1b subnet
     Type: String
-    Default: 10.100.212.0/21
+    Default: 10.100.208.0/21
   pEC2KeyPair:
     Description: Name of existing EC2 key pair for production hosts
     Type: String


### PR DESCRIPTION
*Issue
CIDR for Privates Subnets B from Production VPC use the invalide CIDR. When we apply this cloudformation template, AWS automaticaly convert for right CIDR. So, because of this, the template and reality is diferent.

*Description of changes:
I change for corrects CIDR for these subnets.
This repository is required in quickstart-compliance-pci repository, I pulled a request too for that repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
